### PR TITLE
Case support is available only in galaxy buds+

### DIFF
--- a/buds.js
+++ b/buds.js
@@ -118,7 +118,9 @@ var budsBattIndicator = new Lang.Class({
 				
 				this.leftLabel.set_text(leftBatt + "%");
 				this.rightLabel.set_text(rightBatt + "%");
-				this.caseLabel.set_text(caseBatt.trimEnd() + "%");
+				if (typeof caseBatt !== 'undefined') {
+					this.caseLabel.set_text(caseBatt.trimEnd() + "%");
+				}
 				if (parseInt(rightBatt) <= parseInt(leftBatt)){
 					this.buttonText.set_text(rightBatt + "%");
 				} else {


### PR DESCRIPTION
Extension fails if used with galaxy buds 
[budsBattery] TypeError: caseBatt is undefined
case battery indicator is only available in galaxy buds+